### PR TITLE
Add missing apostrophe

### DIFF
--- a/AbstractAlgebra/notes/notes.tex
+++ b/AbstractAlgebra/notes/notes.tex
@@ -25,7 +25,7 @@ and I'm reading the textbook along side the class, so I'm starting here too.
 Integers are everywhere, we all get them intuitively after years of grade
 school, so it's a good choice for learning groups. This chapter is building up
 to what how we can use modulo to study finite groups, and I think we're gonna be
-using them a lot. Lets dive in.
+using them a lot. Let's dive in.
 \section{Division}
 
 Before we can understand what it means to take a modulo, we gotta figure out how we build integers. Thats gonna involve prime numbers, but to understand why those are special we need to know what it means to divide an integer. Never mind that we need the definition of multiplication to figure that out first.


### PR DESCRIPTION
I began reading [AbstractAlgebra/notes/notes.tex](https://github.com/philipfranchi/math/compare/main...emensch:math:patch-1#diff-748682c814ec97f466659f85900fdaabc6c72d092cd5675712a8d5f8b5a40e3e) but my comprehension was stymied by the missing apostrophe in the common "let us" contraction "let's." It took me a few hours to figure out but I think this fix will greatly improve reader comprehension of the document.